### PR TITLE
Fissions alt

### DIFF
--- a/examples/eg1/config.dat
+++ b/examples/eg1/config.dat
@@ -5,13 +5,13 @@ capacity
 dispersal
 {
     init_migration_rate 0.001
-    left_demes 5
-    right_demes 3
+    left_demes -1
+    right_demes -1
     migration_rate_scales_with_K 1
 }
 mutation
 {
-    mu_driver_birth 0
+    mu_driver_birth 0.0001
     mu_driver_migration 0
 }
 fitness
@@ -35,6 +35,7 @@ stopping_conditions
     max_time 86400
     max_generations 10000
     max_fissions 23
+    turnover .3
 }
 initial_conditions
 {
@@ -48,5 +49,5 @@ output_indicators
 }
 rng_seed
 {
-    seed 69420
+    seed 6969
 }

--- a/examples/eg1/config.dat
+++ b/examples/eg1/config.dat
@@ -1,10 +1,12 @@
 capacity
 {
-    deme_carrying_capacity 14
+    deme_carrying_capacity 100
 }
 dispersal
 {
-    init_migration_rate 0.000001
+    init_migration_rate 0.001
+    left_demes 5
+    right_demes 3
     migration_rate_scales_with_K 1
 }
 mutation
@@ -23,30 +25,21 @@ fitness
 }
 methylation
 {
-    meth_rate 0.01
-    demeth_rate 0.01
-    fCpG_loci_per_cell 1000
+    meth_rate 0.001
+    demeth_rate 0.0015
+    fCpG_loci_per_cell 1200
     manual_array -1
-}
-fission_times
-{
-    t0 0
-    tL1 5
-    tL2 7
-    tL3 9
-    tR1 16
-    tR2 22
-    tR3 28
 }
 stopping_conditions
 {
     max_time 86400
-    max_generations 1000
-    max_fissions 35
+    max_generations 10000
+    max_fissions 23
 }
 initial_conditions
 {
     init_pop 1
+    fission_config 0
 }
 output_indicators
 {
@@ -55,5 +48,5 @@ output_indicators
 }
 rng_seed
 {
-    seed 69
+    seed 69420
 }

--- a/examples/eg2/config.dat
+++ b/examples/eg2/config.dat
@@ -4,29 +4,29 @@ capacity
 }
 dispersal
 {
-    init_migration_rate 0.0001
-    left_demes 4
-    right_demes 4
+    init_migration_rate 0.001
+    left_demes -1
+    right_demes -1
     migration_rate_scales_with_K 1
 }
 mutation
 {
-    mu_driver_birth 0.00001
+    mu_driver_birth 0.0001
     mu_driver_migration 0
 }
 fitness
 {
     normal_birth_rate 0
     baseline_death_rate 0
-    s_driver_birth 0.1
+    s_driver_birth 0
     s_driver_migration 0
     max_relative_birth_rate 10
     max_relative_migration_rate 10
 }
 methylation
 {
-    meth_rate 0.009
-    demeth_rate 0.005
+    meth_rate 0.001
+    demeth_rate 0.0015
     fCpG_loci_per_cell 1200
     manual_array -1
 }
@@ -35,6 +35,7 @@ stopping_conditions
     max_time 86400
     max_generations 10000
     max_fissions 23
+    turnover .3
 }
 initial_conditions
 {
@@ -48,5 +49,5 @@ output_indicators
 }
 rng_seed
 {
-    seed 69420
+    seed 6969
 }

--- a/examples/eg2/config.dat
+++ b/examples/eg2/config.dat
@@ -1,48 +1,40 @@
 capacity
 {
-    deme_carrying_capacity 11
+    deme_carrying_capacity 1000
 }
 dispersal
 {
-    init_migration_rate 0.00009
+    init_migration_rate 0.0001
+    left_demes 4
+    right_demes 4
     migration_rate_scales_with_K 1
 }
 mutation
 {
-    mu_driver_birth 0.0001
+    mu_driver_birth 0.00001
     mu_driver_migration 0
 }
 fitness
 {
     normal_birth_rate 0
     baseline_death_rate 0
-    s_driver_birth 0.3
+    s_driver_birth 0.1
     s_driver_migration 0
     max_relative_birth_rate 10
     max_relative_migration_rate 10
 }
 methylation
 {
-    meth_rate 0.005
+    meth_rate 0.009
     demeth_rate 0.005
     fCpG_loci_per_cell 1200
     manual_array -1
 }
-fission_times
-{
-    t0 0.01
-    tL1 0.2
-    tL2 0.55
-    tL3 0.6
-    tR1 0.1
-    tR2 0.49
-    tR3 0.6
-}
 stopping_conditions
 {
     max_time 86400
-    max_generations 60
-    max_fissions 35
+    max_generations 10000
+    max_fissions 23
 }
 initial_conditions
 {
@@ -56,5 +48,5 @@ output_indicators
 }
 rng_seed
 {
-    seed 15
+    seed 69420
 }

--- a/examples/eg3/config.dat
+++ b/examples/eg3/config.dat
@@ -1,32 +1,32 @@
 capacity
 {
-    deme_carrying_capacity 1000
+    deme_carrying_capacity 20
 }
 dispersal
 {
-    init_migration_rate 0.0001
-    left_demes 4
-    right_demes 4
+    init_migration_rate 0.001
+    left_demes -1
+    right_demes -1
     migration_rate_scales_with_K 1
 }
 mutation
 {
-    mu_driver_birth 0.00001
+    mu_driver_birth 0.0001
     mu_driver_migration 0
 }
 fitness
 {
     normal_birth_rate 0
     baseline_death_rate 0
-    s_driver_birth 0.1
+    s_driver_birth 0
     s_driver_migration 0
     max_relative_birth_rate 10
     max_relative_migration_rate 10
 }
 methylation
 {
-    meth_rate 0.009
-    demeth_rate 0.005
+    meth_rate 0.001
+    demeth_rate 0.0015
     fCpG_loci_per_cell 1200
     manual_array -1
 }
@@ -35,6 +35,7 @@ stopping_conditions
     max_time 86400
     max_generations 10000
     max_fissions 23
+    turnover .3
 }
 initial_conditions
 {
@@ -48,5 +49,5 @@ output_indicators
 }
 rng_seed
 {
-    seed 69420
+    seed 6969
 }

--- a/examples/eg3/config.dat
+++ b/examples/eg3/config.dat
@@ -1,10 +1,12 @@
 capacity
 {
-    deme_carrying_capacity 13
+    deme_carrying_capacity 1000
 }
 dispersal
 {
-    init_migration_rate 0.000001
+    init_migration_rate 0.0001
+    left_demes 4
+    right_demes 4
     migration_rate_scales_with_K 1
 }
 mutation
@@ -23,37 +25,28 @@ fitness
 }
 methylation
 {
-    meth_rate 0.01
-    demeth_rate 0.01
-    fCpG_loci_per_cell 1000
+    meth_rate 0.009
+    demeth_rate 0.005
+    fCpG_loci_per_cell 1200
     manual_array -1
-}
-fission_times
-{
-    t0 0
-    tL1 5
-    tL2 7
-    tL3 9
-    tR1 16
-    tR2 22
-    tR3 28
 }
 stopping_conditions
 {
     max_time 86400
-    max_generations 1000
-    max_fissions 35
+    max_generations 10000
+    max_fissions 23
 }
 initial_conditions
 {
     init_pop 1
+    fission_config 0
 }
 output_indicators
 {
     write_clones_file 1
     write_demes_file 1
 }
-seed
+rng_seed
 {
-    seed 69
+    seed 69420
 }

--- a/include/methdemon/initialise.hpp
+++ b/include/methdemon/initialise.hpp
@@ -9,6 +9,7 @@
 #include <string>
 
 DerivedParameters deriveParameters(const InputParameters& params);
+int calculateMaxGenerations(float fission_rate, int deme_carrying_capacity);
 // TO DO: files for output - most functions needed
 
 #endif // INITIALISE_HPP

--- a/include/methdemon/initialise.hpp
+++ b/include/methdemon/initialise.hpp
@@ -9,7 +9,5 @@
 #include <string>
 
 DerivedParameters deriveParameters(const InputParameters& params);
-int calculateMaxGenerations(float fission_rate, int deme_carrying_capacity);
-// TO DO: files for output - most functions needed
 
 #endif // INITIALISE_HPP

--- a/include/methdemon/parameters.hpp
+++ b/include/methdemon/parameters.hpp
@@ -36,6 +36,7 @@ struct InputParameters {
     int max_time;
     int max_generations;
     int max_fissions;
+    float turnover;
 
     // initial conditions
     int init_pop;

--- a/include/methdemon/parameters.hpp
+++ b/include/methdemon/parameters.hpp
@@ -8,15 +8,8 @@ struct InputParameters {
     // dispersal
     float init_migration_rate;
     int migration_rate_scales_with_K;
-
-    // fission times (in numbers of fissions)
-    float t0;
-    float tL1;
-    float tL2;
-    float tL3;
-    float tR1;
-    float tR2;
-    float tR3;
+    int left_demes;
+    int right_demes;
 
     // fitness
     float normal_birth_rate;
@@ -60,13 +53,12 @@ struct DerivedParameters {
     float dmax; // any genotypes that differ by at least this many mutations are considered totally unrelated (i.e. the distance between them is 1)
     int max_bintree_elements=0; // maximum number of bintree elements = max_demes * (1/SET_SIZE + 1/SET_SIZE^2 + ...) < max_demes/(SET_SIZE-1); allow an extra 10% due to rounding up
     int max_bintree_clone_elements_per_deme=0;
-    bool use_clone_bintrees=false; // whether to use clone bintrees: faster for large K, but a waste of memory for small K
     int max_clones_per_deme;
     int max_genotypes;
     int max_driver_genotypes;
     int max_clones;
     int max_demes = 8;
-    int max_generations;
+    float fission_modifier;
 };
 
 struct EventCounter {

--- a/include/methdemon/parameters.hpp
+++ b/include/methdemon/parameters.hpp
@@ -66,6 +66,7 @@ struct DerivedParameters {
     int max_driver_genotypes;
     int max_clones;
     int max_demes = 8;
+    int max_generations;
 };
 
 struct EventCounter {

--- a/include/methdemon/tumour.hpp
+++ b/include/methdemon/tumour.hpp
@@ -22,6 +22,7 @@ private:
     int maxGens = 0;
     // misc
     int fissionConfig = 0;
+    bool turnoverIndicator = false;
 public:
     // Constructor
     Tumour(const InputParameters& params, const DerivedParameters& d_params);
@@ -42,9 +43,11 @@ public:
     int getNumGenotypes() const { return genotypes.size(); }
     float getGensElapsed() const { return gensElapsed; }
     float getOutputTimer() const { return outputTimer; }
+    bool getTurnoverIndicator() const { return turnoverIndicator; }
     Deme& getDeme(int index) { return demes[index]; }
     // Setters
     void setGensElapsed(float gensAdded = 0) { gensElapsed += gensAdded; }
+    void setTurnoverIndicator(bool indi = true) { turnoverIndicator = indi; }
 };
 
 #endif // TUMOUR_HPP

--- a/include/methdemon/tumour.hpp
+++ b/include/methdemon/tumour.hpp
@@ -14,39 +14,30 @@ private:
     // cell and genotype ID tracking
     int nextGenotypeID = 1;
     int nextCellID = 1;
+    int leftDemes = 1;
+    int rightDemes = 0;
     // temporal variables
     float gensElapsed = 0;
     float outputTimer = 0;
-    std::vector<float> fissionTimes;
-    float* nextFissionL = 0;
-    float* nextFissionR = 0;
     int maxGens = 0;
-    // sums of rates
-    // double sumBirthRates = 0;
-    // double sumDeathRates = 0;
-    // double sumMigRates = 0;
     // misc
     int fissionConfig = 0;
 public:
     // Constructor
     Tumour(const InputParameters& params, const DerivedParameters& d_params);
-    // // deme rates
-    // void calculate_deme_birth_rate(Deme& deme);
-    // void calculate_deme_migration_rate(Deme& deme);
-    // void calculate_all_rates(const InputParameters& params, const DerivedParameters& d_params);
     // choose deme, cell and event type
     int chooseDeme();
     int chooseCell(int chosenDeme) { return demes[chosenDeme].chooseCell(); };
     std::string chooseEventType(int chosenDeme, int chosenCell);
     //perform event
-    void event(const InputParameters& params);
+    void event(const InputParameters& params, const DerivedParameters& d_params);
     // sum all rates (for time tracking)
     float sumAllRates();
     // Getters
     int getNextCellID() const { return nextCellID; }
     int getNextGenotypeID() const { return nextGenotypeID; }
     int getNumCells() const;
-    float fissionsPerDeme();
+    float getFissionsPerDeme();
     int getNumDemes() const { return demes.size(); }
     int getNumGenotypes() const { return genotypes.size(); }
     float getGensElapsed() const { return gensElapsed; }

--- a/resources/config.dat
+++ b/resources/config.dat
@@ -1,15 +1,17 @@
 capacity
 {
-    deme_carrying_capacity 14
+    deme_carrying_capacity 100
 }
 dispersal
 {
-    init_migration_rate 0.00001
+    init_migration_rate 0.001
+    left_demes -1
+    right_demes -1
     migration_rate_scales_with_K 1
 }
 mutation
 {
-    mu_driver_birth 0
+    mu_driver_birth 0.0001
     mu_driver_migration 0
 }
 fitness
@@ -23,30 +25,22 @@ fitness
 }
 methylation
 {
-    meth_rate 0.01
-    demeth_rate 0.01
-    fCpG_loci_per_cell 1000
+    meth_rate 0.001
+    demeth_rate 0.0015
+    fCpG_loci_per_cell 1200
     manual_array -1
-}
-fission_times
-{
-    t0 0
-    tL1 7
-    tL2 13
-    tL3 20
-    tR1 7
-    tR2 13
-    tR3 20
 }
 stopping_conditions
 {
     max_time 86400
-    max_generations 100
-    max_fissions 30
+    max_generations 10000
+    max_fissions 23
+    turnover .3
 }
 initial_conditions
 {
     init_pop 1
+    fission_config 0
 }
 output_indicators
 {
@@ -55,5 +49,5 @@ output_indicators
 }
 rng_seed
 {
-    seed 69
+    seed 6969
 }

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-lldb bin/methdemon -o "settings set -- target.run-args resources config.dat"
+lldb bin/methdemon -o "settings set -- target.run-args examples/eg1 config.dat"

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -19,15 +19,15 @@ Cell& Cell::operator=(Cell&& other) noexcept {
     return *this;
 }
 // Copy constructor
-Cell::Cell(const Cell& other) 
-    : identity(other.identity), 
+Cell::Cell(const Cell& other)
+    : identity(other.identity),
       genotype(other.genotype),
-      deme(other.deme), 
-      numMeth(other.numMeth), 
-      numDemeth(other.numDemeth), 
-      fcpgs(other.fcpgs), 
+      deme(other.deme),
+      numMeth(other.numMeth),
+      numDemeth(other.numDemeth),
+      fcpgs(other.fcpgs),
       methArray(other.methArray),
-      methRate(other.methRate), 
+      methRate(other.methRate),
       demethRate(other.demethRate) {}
 // Copy assignment operator
 Cell& Cell::operator=(const Cell& other) {
@@ -84,14 +84,20 @@ void Cell::methylation() {
 
 /////// Mutations
 // mutation event
-void Cell::mutation(int* next_genotype_id, float gensElapsed, const InputParameters& params) {
-    int newBirthMut = RandomNumberGenerator::getInstance().poissonDist(genotype->getMuDriverBirth());
-    int newMigMut = RandomNumberGenerator::getInstance().poissonDist(genotype->getMuDriverMig());
+void Cell::mutation(int *next_genotype_id, float gensElapsed,
+                    const InputParameters &params) {
+  int newBirthMut = RandomNumberGenerator::getInstance().poissonDist(
+      genotype->getMuDriverBirth());
+  int newMigMut = RandomNumberGenerator::getInstance().poissonDist(
+      genotype->getMuDriverMig());
 
-    if (newBirthMut || newMigMut) {
-        std::shared_ptr<Genotype> newGenotype = std::make_shared<Genotype>(genotype->getIdentity(), (*next_genotype_id)++, genotype->getNumBirthMut() + newBirthMut, genotype->getNumMigMut() + newMigMut, 0, 0, gensElapsed, params);
-        newGenotype->setBirthRate();
-        newGenotype->setMigrationRate();
-        genotype = newGenotype;
+  if (newBirthMut || newMigMut) {
+    std::shared_ptr<Genotype> newGenotype = std::make_shared<Genotype>(
+        genotype->getIdentity(), (*next_genotype_id)++,
+        genotype->getNumBirthMut() + newBirthMut,
+        genotype->getNumMigMut() + newMigMut, 0, 0, gensElapsed, params);
+    newGenotype->setBirthRate();
+    newGenotype->setMigrationRate();
+    genotype = newGenotype;
     }
 }

--- a/src/deme.cpp
+++ b/src/deme.cpp
@@ -138,7 +138,7 @@ int Deme::chooseCell() {
 }
 // cell division
 void Deme::cellDivision(int parentIndex, int *nextCellID, int *nextGenotypeID,
-                        float gensElapsed, const InputParameters &params) {
+                        float const gensElapsed, const InputParameters &params) {
   Cell &parent = cellList[parentIndex];
   Cell daughter =
       Cell((*nextCellID)++, parent.getGenotype(), identity, parent.getNumMeth(),

--- a/src/deme.cpp
+++ b/src/deme.cpp
@@ -53,7 +53,7 @@ void Deme::calculateAverageArray() {
 Deme Deme::demeFission(float originTime, bool firstFission) {
     fissions++;
     // initialise new deme
-    Deme newDeme = Deme(K, side, identity + 1, 0, fissions, 0, baseDeathRate, 0, 0);
+    Deme newDeme = Deme(K, side, identity + 1, 0, 0, 0, baseDeathRate, 0, 0);
     if (firstFission) newDeme.setSide("right");
     moveCells(newDeme);
     // update origin deme
@@ -137,15 +137,19 @@ int Deme::chooseCell() {
     }
 }
 // cell division
-void Deme::cellDivision(int parentIndex, int* nextCellID, int* nextGenotypeID, float gensElapsed, const InputParameters& params) {
-    Cell& parent = cellList[parentIndex];
-    Cell daughter = Cell((*nextCellID)++, parent.getGenotype(), identity, parent.getNumMeth(), parent.getNumDemeth(), parent.getFCpGs(), parent.getMethArray(), parent.getMethRate(), parent.getDemethRate());
-    parent.methylation();
-    daughter.methylation();
-    parent.mutation(nextGenotypeID, gensElapsed, params);
-    daughter.mutation(nextGenotypeID, gensElapsed, params);
-    cellList.push_back(std::move(daughter));
-    increment(1);
+void Deme::cellDivision(int parentIndex, int *nextCellID, int *nextGenotypeID,
+                        float gensElapsed, const InputParameters &params) {
+  Cell &parent = cellList[parentIndex];
+  Cell daughter =
+      Cell((*nextCellID)++, parent.getGenotype(), identity, parent.getNumMeth(),
+           parent.getNumDemeth(), parent.getFCpGs(), parent.getMethArray(),
+           parent.getMethRate(), parent.getDemethRate());
+  parent.methylation();
+  daughter.methylation();
+  parent.mutation(nextGenotypeID, gensElapsed, params);
+  daughter.mutation(nextGenotypeID, gensElapsed, params);
+  cellList.push_back(std::move(daughter));
+  increment(1);
 }
 // cell death
 void Deme::cellDeath(int cellIndex) {

--- a/src/genotype.cpp
+++ b/src/genotype.cpp
@@ -1,21 +1,25 @@
 #include "genotype.hpp"
 
 /////// Constructor
-Genotype::Genotype(int parent, int identity,
-    int numBirthMut, int numMigMut, float birthRate, float migrationRate, float originTime, const InputParameters& params)
-    : parent(parent), identity(identity), numBirthMut(numBirthMut), numMigMut(numMigMut),
-    birthRate(birthRate), migrationRate(migrationRate), originTime(originTime),
-    muDriverBirth(params.mu_driver_birth), muDriverMig(params.mu_driver_migration), 
-    inputMigRate(params.init_migration_rate), maxRelBirth(params.max_relative_birth_rate),
-    maxRelMig(params.max_relative_migration_rate), sDriverBirth(params.s_driver_birth),
-    sDriverMig(params.s_driver_migration) {}
+Genotype::Genotype(int parent, int identity, int numBirthMut, int numMigMut,
+                   float birthRate, float migrationRate, float originTime,
+                   const InputParameters &params)
+    : parent(parent), identity(identity), numBirthMut(numBirthMut),
+      numMigMut(numMigMut), birthRate(birthRate), migrationRate(migrationRate),
+      muDriverBirth(params.mu_driver_birth),
+      muDriverMig(params.mu_driver_migration),
+      inputMigRate(params.init_migration_rate),
+      maxRelBirth(params.max_relative_birth_rate),
+      maxRelMig(params.max_relative_migration_rate),
+      sDriverBirth(params.s_driver_birth),
+      sDriverMig(params.s_driver_migration), originTime(originTime) {}
 
 /////// Setters
 // birth rate
 void Genotype::setBirthRate() {
     birthRate = 1;
 
-    if (maxRelBirth >= 0) 
+    if (maxRelBirth >= 0)
         for(int i = 0; i < numBirthMut; i++) {
             float rnd = RandomNumberGenerator::getInstance().expDist(1);
             birthRate = birthRate * (1 + sDriverBirth * (1 - birthRate / maxRelBirth) * rnd);
@@ -25,7 +29,7 @@ void Genotype::setBirthRate() {
             float rnd = RandomNumberGenerator::getInstance().expDist(1);
             birthRate = birthRate * (1 + sDriverBirth * rnd);
         }
-    
+
     if (birthRate >= maxRelBirth + 100) {
         std::cout << "ERROR: Birth rate at carrying capacity exceeds death rate." << std::endl;
         exit(1);
@@ -35,7 +39,7 @@ void Genotype::setBirthRate() {
 void Genotype::setMigrationRate() {
     migrationRate = inputMigRate;
 
-    if (maxRelMig >= 0) 
+    if (maxRelMig >= 0)
         for(int i = 0; i < numMigMut; i++) {
             float rnd = RandomNumberGenerator::getInstance().expDist(1);
             migrationRate = migrationRate * (1 + sDriverMig * (1 - migrationRate / (maxRelMig + inputMigRate)) * rnd);

--- a/src/initialise.cpp
+++ b/src/initialise.cpp
@@ -13,6 +13,10 @@ DerivedParameters deriveParameters(const InputParameters& params) {
     int predicted_clones_per_deme = max(min(std::ceil(d_params.K * max_driver_mu * 400), d_params.K), 1);
     d_params.max_clones = min(max(d_params.max_genotypes, 8 * predicted_clones_per_deme), max_pop);
     d_params.fission_modifier = static_cast<float>(params.max_fissions) / 2;
-    d_params.max_demes = params.left_demes + params.right_demes;
+    if (params.left_demes != -1 && params.right_demes != -1) {
+        d_params.max_demes = params.left_demes + params.right_demes;
+    } else {
+        d_params.max_demes = 8;
+    }
     return d_params;
 }

--- a/src/initialise.cpp
+++ b/src/initialise.cpp
@@ -1,11 +1,5 @@
 #include "initialise.hpp"
 
-// set number of generations for the run so that the size of the tumour is
-// roughly constant (around 5,000,000 glands)
-int calculateMaxGenerations(float fission_rate, int deme_carrying_capacity) {
-    return 0;
-}
-
 DerivedParameters deriveParameters(const InputParameters& params) {
     DerivedParameters d_params;
     d_params.fcpgs = params.fCpG_loci_per_cell * 2;
@@ -18,6 +12,7 @@ DerivedParameters deriveParameters(const InputParameters& params) {
     d_params.max_driver_genotypes = min(400 * max(max_driver_mu * max_pop, (params.meth_rate + params.demeth_rate) * max_pop), 1e8);
     int predicted_clones_per_deme = max(min(std::ceil(d_params.K * max_driver_mu * 400), d_params.K), 1);
     d_params.max_clones = min(max(d_params.max_genotypes, 8 * predicted_clones_per_deme), max_pop);
-    d_params.max_generations = calculateMaxGenerations(params.init_migration_rate, params.deme_carrying_capacity);
+    d_params.fission_modifier = static_cast<float>(params.max_fissions) / 2;
+    d_params.max_demes = params.left_demes + params.right_demes;
     return d_params;
 }

--- a/src/initialise.cpp
+++ b/src/initialise.cpp
@@ -1,5 +1,11 @@
 #include "initialise.hpp"
 
+// set number of generations for the run so that the size of the tumour is
+// roughly constant (around 5,000,000 glands)
+int calculateMaxGenerations(float fission_rate, int deme_carrying_capacity) {
+    return 0;
+}
+
 DerivedParameters deriveParameters(const InputParameters& params) {
     DerivedParameters d_params;
     d_params.fcpgs = params.fCpG_loci_per_cell * 2;
@@ -12,6 +18,6 @@ DerivedParameters deriveParameters(const InputParameters& params) {
     d_params.max_driver_genotypes = min(400 * max(max_driver_mu * max_pop, (params.meth_rate + params.demeth_rate) * max_pop), 1e8);
     int predicted_clones_per_deme = max(min(std::ceil(d_params.K * max_driver_mu * 400), d_params.K), 1);
     d_params.max_clones = min(max(d_params.max_genotypes, 8 * predicted_clones_per_deme), max_pop);
-
+    d_params.max_generations = calculateMaxGenerations(params.init_migration_rate, params.deme_carrying_capacity);
     return d_params;
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -46,6 +46,7 @@ InputParameters readParameters(const boost::property_tree::ptree& pt, const std:
     params.max_time = pt.get<int>("stopping_conditions.max_time");
     params.max_generations = pt.get<int>("stopping_conditions.max_generations");
     params.max_fissions = pt.get<int>("stopping_conditions.max_fissions");
+    params.turnover = pt.get<float>("stopping_conditions.turnover");
 
     params.init_pop = pt.get<int>("initial_conditions.init_pop");
     params.fission_config = pt.get<int>("initial_conditions.fission_config");

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -22,7 +22,12 @@ InputParameters readParameters(const boost::property_tree::ptree& pt, const std:
     params.deme_carrying_capacity = pt.get<int>("capacity.deme_carrying_capacity");
 
     params.init_migration_rate = pt.get<float>("dispersal.init_migration_rate");
+    params.left_demes = pt.get<int>("dispersal.left_demes");
+    params.right_demes = pt.get<int>("dispersal.right_demes");
     params.migration_rate_scales_with_K = pt.get<int>("dispersal.migration_rate_scales_with_K");
+
+    params.mu_driver_birth = pt.get<float>("mutation.mu_driver_birth");
+    params.mu_driver_migration = pt.get<float>("mutation.mu_driver_migration");
 
     params.normal_birth_rate = pt.get<float>("fitness.normal_birth_rate");
     params.baseline_death_rate = pt.get<float>("fitness.baseline_death_rate");
@@ -30,9 +35,6 @@ InputParameters readParameters(const boost::property_tree::ptree& pt, const std:
     params.s_driver_migration = pt.get<float>("fitness.s_driver_migration");
     params.max_relative_birth_rate = pt.get<float>("fitness.max_relative_birth_rate");
     params.max_relative_migration_rate = pt.get<float>("fitness.max_relative_migration_rate");
-
-    params.mu_driver_birth = pt.get<float>("mutation.mu_driver_birth");
-    params.mu_driver_migration = pt.get<float>("mutation.mu_driver_migration");
 
     params.meth_rate = pt.get<float>("methylation.meth_rate");
     params.demeth_rate = pt.get<float>("methylation.demeth_rate");

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -24,14 +24,6 @@ InputParameters readParameters(const boost::property_tree::ptree& pt, const std:
     params.init_migration_rate = pt.get<float>("dispersal.init_migration_rate");
     params.migration_rate_scales_with_K = pt.get<int>("dispersal.migration_rate_scales_with_K");
 
-    params.t0 = pt.get<float>("fission_times.t0");
-    params.tL1 = pt.get<float>("fission_times.tL1");
-    params.tL2 = pt.get<float>("fission_times.tL2");
-    params.tL3 = pt.get<float>("fission_times.tL3");
-    params.tR1 = pt.get<float>("fission_times.tR1");
-    params.tR2 = pt.get<float>("fission_times.tR2");
-    params.tR3 = pt.get<float>("fission_times.tR3");
-
     params.normal_birth_rate = pt.get<float>("fitness.normal_birth_rate");
     params.baseline_death_rate = pt.get<float>("fitness.baseline_death_rate");
     params.s_driver_birth = pt.get<float>("fitness.s_driver_birth");

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -5,9 +5,12 @@ void FileOutput::writeDemesHeader() {
 }
 void FileOutput::writeDemesFile(Tumour& tumour) {
     for (int i = 0; i < tumour.getNumDemes(); i++) {
-        file << tumour.getGensElapsed() << "," << i << "," << tumour.getDeme(i).getSide() << "," << tumour.getDeme(i).getPopulation() << "," << tumour.getDeme(i).getOriginTime() << ",";
-        for (int j = 0; j < tumour.getDeme(i).getAverageArray().size(); j++) {
-            file << tumour.getDeme(i).getAverageArray()[j] << ";";
+      file << tumour.getGensElapsed() << "," << i << ","
+           << tumour.getDeme(i).getSide() << ","
+           << tumour.getDeme(i).getPopulation() << ","
+           << tumour.getDeme(i).getOriginTime() << ",";
+      for (int j = 0; j < tumour.getDeme(i).getAverageArray().size(); j++) {
+        file << tumour.getDeme(i).getAverageArray()[j] << ";";
         }
         file << std::endl;
     }

--- a/src/runsim.cpp
+++ b/src/runsim.cpp
@@ -35,8 +35,8 @@ void runSim(const std::string& input_and_output_path,
         tumour.setGensElapsed(gensAdded);
         outputTimer += gensAdded;
 
-        // write to stdout and files every 5 generations
-        if(outputTimer >= 5) {
+        // write to stdout and files every 10 generations
+        if(outputTimer >= 10) {
             int numGenotypes = tumour.getNumGenotypes();
             int numDemes = tumour.getNumDemes();
             int numCells = tumour.getNumCells();
@@ -52,7 +52,43 @@ void runSim(const std::string& input_and_output_path,
                       << tumour.getNextGenotypeID()
                       << " genotypes ever created." << std::endl;
             outputTimer = 0;
-            finalDemes.writeDemesFile(tumour);
+            if (params.write_demes_file) finalDemes.writeDemesFile(tumour);
+        }
+    }
+
+    float turnoverTime = tumour.getGensElapsed() * ( 1 + params.turnover );
+    std::cout << "Turnover start time: " << tumour.getGensElapsed()
+        << std::endl;
+    std::cout << "Turnover end time: " << turnoverTime << std::endl;
+    tumour.setTurnoverIndicator();
+    while(tumour.getGensElapsed() < turnoverTime) {
+      tumour.event(params, d_params);
+
+      // update time
+      iterations++;
+      gensAdded = calculateTime(tumour);
+      tumour.setGensElapsed(gensAdded);
+      outputTimer += gensAdded;
+
+      // write to stdout and files every 5 generations
+      if (outputTimer >= 5) {
+        int numGenotypes = tumour.getNumGenotypes();
+        int numDemes = tumour.getNumDemes();
+        int numCells = tumour.getNumCells();
+        std::cout << "Generations elapsed: " << tumour.getGensElapsed()
+                  << ", Iterations: " << iterations
+                  << ", Mean Fissions: " << tumour.getFissionsPerDeme()
+                  << std::endl;
+        std::cout << "Number of cells: " << numCells << std::endl;
+        std::cout << "Number of driver genotypes: " << numGenotypes
+                  << std::endl;
+        std::cout << "Number of demes: " << numDemes << std::endl;
+        std::cout << tumour.getNextCellID() << " cells ever created; "
+                  << tumour.getNextGenotypeID() << " genotypes ever created."
+                  << std::endl;
+        outputTimer = 0;
+        if (params.write_demes_file)
+          finalDemes.writeDemesFile(tumour);
         }
     }
 

--- a/src/runsim.cpp
+++ b/src/runsim.cpp
@@ -25,31 +25,10 @@ void runSim(const std::string& input_and_output_path,
     std::cout << "Initialised simulation." << std::endl;
     // start timer
     auto start = std::chrono::high_resolution_clock::now();
-    bool wIndicator = true;
-    bool wIndicator2 = true;
-    bool wIndicator4 = true;
     // sort out column headers in output files
-    while(tumour.getGensElapsed() < params.max_generations) {
-        //tumour.fissionsPerDeme() < params.max_fissions) {
-        // update all rate sums
-        // tumour.calculate_all_rates(params, d_params);
-        // choose deme, cell, event
-        tumour.event(params);
-        if (wIndicator && tumour.getNumCells() == 2) {
-            std::cout << "First cell division written." << std::endl;
-            finalDemes.writeDemesFile(tumour);
-            wIndicator = false;
-        }
-        if (wIndicator2 && tumour.getNumDemes() == 2) {
-            std::cout << "2 demes." << std::endl;
-            finalDemes.writeDemesFile(tumour);
-            wIndicator2 = false;
-        }
-        if (wIndicator4 && tumour.getNumDemes() == 4) {
-            std::cout << "4 demes." << std::endl;
-            finalDemes.writeDemesFile(tumour);
-            wIndicator4 = false;
-        }
+    while(tumour.getFissionsPerDeme() < params.max_fissions ||
+            tumour.getNumDemes() < d_params.max_demes) {
+        tumour.event(params, d_params);
 
         // update time
         iterations++;
@@ -62,11 +41,17 @@ void runSim(const std::string& input_and_output_path,
             int numGenotypes = tumour.getNumGenotypes();
             int numDemes = tumour.getNumDemes();
             int numCells = tumour.getNumCells();
-            std::cout << "Generations elapsed: " << tumour.getGensElapsed() << ", Iterations: " << iterations << std::endl;
+            std::cout << "Generations elapsed: " << tumour.getGensElapsed()
+                      << ", Iterations: " << iterations
+                      << ", Mean Fissions: " << tumour.getFissionsPerDeme()
+                      << std::endl;
             std::cout << "Number of cells: " << numCells << std::endl;
-            std::cout << "Number of driver genotypes: " << numGenotypes << std::endl;
+            std::cout << "Number of driver genotypes: " << numGenotypes
+                      << std::endl;
             std::cout << "Number of demes: " << numDemes << std::endl;
-            std::cout << tumour.getNextCellID() << " cells ever created; " << tumour.getNextGenotypeID() << " genotypes ever created." << std::endl;
+            std::cout << tumour.getNextCellID() << " cells ever created; "
+                      << tumour.getNextGenotypeID()
+                      << " genotypes ever created." << std::endl;
             outputTimer = 0;
         }
     }
@@ -76,7 +61,7 @@ void runSim(const std::string& input_and_output_path,
     std::cout << "End of simulation." << std::endl
     << tumour.getNumDemes() << " demes; " << tumour.getNumCells() << " cells; "
     << tumour.getGensElapsed() << " generations; "
-    << tumour.fissionsPerDeme() << " mean fissions per deme." << std::endl;
+    << tumour.getFissionsPerDeme() << " mean fissions per deme." << std::endl;
     std::cout << "Running time: " << elapsed.count() << " seconds." << std::endl;
     finalDemes.writeDemesFile(tumour);
 }

--- a/src/runsim.cpp
+++ b/src/runsim.cpp
@@ -21,7 +21,6 @@ void runSim(const std::string& input_and_output_path,
     // initialise tumour
     Tumour tumour(params, d_params);
     // NOTE: Implement event counter eventually (not that important tbh)
-    //EventCounter event_counter;
     std::cout << "Initialised simulation." << std::endl;
     // start timer
     auto start = std::chrono::high_resolution_clock::now();
@@ -36,7 +35,7 @@ void runSim(const std::string& input_and_output_path,
         tumour.setGensElapsed(gensAdded);
         outputTimer += gensAdded;
 
-        // write to stdout every 5 generations
+        // write to stdout and files every 5 generations
         if(outputTimer >= 5) {
             int numGenotypes = tumour.getNumGenotypes();
             int numDemes = tumour.getNumDemes();
@@ -53,6 +52,7 @@ void runSim(const std::string& input_and_output_path,
                       << tumour.getNextGenotypeID()
                       << " genotypes ever created." << std::endl;
             outputTimer = 0;
+            finalDemes.writeDemesFile(tumour);
         }
     }
 

--- a/src/tumour.cpp
+++ b/src/tumour.cpp
@@ -1,150 +1,162 @@
 #include "tumour.hpp"
 
 /////// Constructor
-Tumour::Tumour(const InputParameters& params,
-    const DerivedParameters& d_params) {
-    demes.clear();
-    genotypes.clear();
-    // driver genotypes:
-    std::shared_ptr<Genotype> firstGenotype = std::make_shared<Genotype>(
-        0, 0, 0, 0, 1, params.init_migration_rate, 0, params);
-    genotypes.push_back(firstGenotype);
+Tumour::Tumour(const InputParameters &params,
+               const DerivedParameters &d_params) {
+  demes.clear();
+  genotypes.clear();
+  // driver genotypes:
+  std::shared_ptr<Genotype> firstGenotype = std::make_shared<Genotype>(
+      0, 0, 0, 0, 1, params.init_migration_rate, 0, params);
+  genotypes.push_back(firstGenotype);
 
-    // demes:
-    Deme firstDeme(params.deme_carrying_capacity, "left", 0, 1, 0,
-                   params.baseline_death_rate, params.baseline_death_rate, 1,
-                   params.init_migration_rate);
-    demes.push_back(firstDeme);
-    demes.back().initialise(firstGenotype, params, d_params);
+  // demes:
+  Deme firstDeme(params.deme_carrying_capacity, "left", 0, 1, 0,
+                 params.baseline_death_rate, params.baseline_death_rate, 1,
+                 params.init_migration_rate);
+  demes.push_back(firstDeme);
+  demes.back().initialise(firstGenotype, params, d_params);
 
-    // max gillespie generations to run
-    maxGens = params.max_generations;
+  // max gillespie generations to run
+  maxGens = params.max_generations;
 
-    // fission config
-    fissionConfig = params.fission_config;
+  // fission config
+  fissionConfig = params.fission_config;
 }
 
 /////// Choose events based on rate sums
 // choose deme
 int Tumour::chooseDeme() {
-    std::vector<double> cumRates(demes.size());
-    double r;
-    int res = 0;
+  std::vector<double> cumRates(demes.size());
+  double r;
+  int res = 0;
 
-    if (cumRates.size() == 1) {
-        return res;
+  if (cumRates.size() == 1) {
+    return res;
+  } else {
+    double sumOfRates = demes[0].getSumOfRates();
+    cumRates[0] = sumOfRates;
+    for (int i = 1; i < cumRates.size(); i++) {
+      sumOfRates = demes[i].getSumOfRates();
+      cumRates[i] += sumOfRates + cumRates[i - 1];
     }
-    else {
-        double sumOfRates = demes[0].getSumOfRates();
-        cumRates[0] = sumOfRates;
-        for (int i = 1; i < cumRates.size(); i++) {
-            sumOfRates = demes[i].getSumOfRates();
-            cumRates[i] += sumOfRates + cumRates[i - 1];
-        }
-        double rnd = RandomNumberGenerator::getInstance().unitUnifDist();
-        r = rnd * cumRates.back();
-    }
-    if (cumRates.size() == 2) {
-        res = r < cumRates[0] ? 0 : 1;
-        return res;
-    }
-    else {
-        res = std::lower_bound(cumRates.begin(), cumRates.end(), r) - cumRates.begin();
-        return res;
-    }
+    double rnd = RandomNumberGenerator::getInstance().unitUnifDist();
+    r = rnd * cumRates.back();
+  }
+  if (cumRates.size() == 2) {
+    res = r < cumRates[0] ? 0 : 1;
+    return res;
+  } else {
+    res = std::lower_bound(cumRates.begin(), cumRates.end(), r) -
+          cumRates.begin();
+    return res;
+  }
 }
 // choose event type
 std::string Tumour::chooseEventType(int chosenDeme, int chosenCell) {
-    std::vector<float> cumRates;
-    int ctr = 0;
-    float res;
-    double rnd = RandomNumberGenerator::getInstance().unitUnifDist();
-    // cell birth rate
-    cumRates.push_back(demes[chosenDeme].getCellBirth(chosenCell));
-    ctr++;
-    // cell death rate
-    cumRates.push_back(cumRates[ctr - 1] + demes[chosenDeme].getDeathRate());
-    ctr++;
-    // cell migration rate
-    cumRates.push_back(cumRates[ctr - 1] + demes[chosenDeme].getCellMig(chosenCell));
-    // weighted choice
-    res = rnd * cumRates.back();
-    if(res < cumRates[0]) {
-        return "birth";
-    }
-    else if(res < cumRates[1]) {
-        return "death";
-    }
-    else {
-        return "fission";
-    }
+  std::vector<float> cumRates;
+  int ctr = 0;
+  float res;
+  double rnd = RandomNumberGenerator::getInstance().unitUnifDist();
+  // cell birth rate
+  cumRates.push_back(demes[chosenDeme].getCellBirth(chosenCell));
+  ctr++;
+  // cell death rate
+  cumRates.push_back(cumRates[ctr - 1] + demes[chosenDeme].getDeathRate());
+  ctr++;
+  // cell migration rate
+  if (!turnoverIndicator) {
+    cumRates.push_back(cumRates[ctr - 1] +
+                       demes[chosenDeme].getCellMig(chosenCell));
+  }
+  // weighted choice
+  res = rnd * cumRates.back();
+  if (res < cumRates[0]) {
+    return "birth";
+  } else if (res < cumRates[1]) {
+    return "death";
+  } else {
+    return "fission";
+  }
 }
-// perform event
-void Tumour::event(const InputParameters& params, const DerivedParameters& d_params) {
-    int chosenDeme = chooseDeme();
-    int chosenCell = demes[chosenDeme].chooseCell();
-    std::string eventType = chooseEventType(chosenDeme, chosenCell);
 
-    if (eventType == "birth") {
-        demes[chosenDeme].cellDivision(chosenCell, &nextCellID, &nextGenotypeID, gensElapsed, params);
-    }
-    else if (eventType == "death") {
-        demes[chosenDeme].cellDeath(chosenCell);
-    }
-    else if (eventType == "fission") {
-        float fission_weight = 1.0 / d_params.fission_modifier;
-        float rnd = RandomNumberGenerator::getInstance().unitUnifDist();
-        bool rightIndicator = (rightDemes < params.right_demes &&
-                              demes[chosenDeme].getSide() == "right");
-        bool leftIndicator = (leftDemes < params.left_demes &&
-                              demes[chosenDeme].getSide() == "left");
-        bool sideIndicator = (rightIndicator || leftIndicator);
-        if (sideIndicator && rnd <= fission_weight &&
-            demes.size() < d_params.max_demes) {
-          if (demes.size() == 1) {
-            demes.push_back(demes[chosenDeme].demeFission(gensElapsed, true));
-            rightDemes = 1;
-          } else {
-            demes.push_back(demes[chosenDeme].demeFission(gensElapsed));
-            if (rightIndicator) {
-              rightDemes++;
-            } else if (leftIndicator) {
-              leftDemes++;
-            }
-          }
+// perform event
+void Tumour::event(const InputParameters &params,
+                   const DerivedParameters &d_params) {
+  int chosenDeme = chooseDeme();
+  int chosenCell = demes[chosenDeme].chooseCell();
+  std::string eventType = chooseEventType(chosenDeme, chosenCell);
+
+  if (eventType == "birth") {
+    demes[chosenDeme].cellDivision(chosenCell, &nextCellID, &nextGenotypeID,
+                                   gensElapsed, params);
+  } else if (eventType == "death") {
+    demes[chosenDeme].cellDeath(chosenCell);
+  } else if (eventType == "fission" && demes[chosenDeme].getPopulation() >=
+                                           params.deme_carrying_capacity) {
+    float fission_weight = 1.0 / d_params.fission_modifier;
+    float rnd = RandomNumberGenerator::getInstance().unitUnifDist();
+    if (params.right_demes == -1 || params.left_demes == -1) {
+      if (rnd <= fission_weight && demes.size() < d_params.max_demes) {
+        if (demes.size() == 1) {
+          demes.push_back(demes[chosenDeme].demeFission(gensElapsed, true));
+          rightDemes = 1;
         } else {
-          demes[chosenDeme].pseudoFission();
+          demes.push_back(demes[chosenDeme].demeFission(gensElapsed));
         }
+      } else {
+        demes[chosenDeme].pseudoFission();
+      }
+    } else {
+      bool rightIndicator = (rightDemes < params.right_demes &&
+                             demes[chosenDeme].getSide() == "right");
+      bool leftIndicator = (leftDemes < params.left_demes &&
+                            demes[chosenDeme].getSide() == "left");
+      bool sideIndicator = (rightIndicator || leftIndicator);
+      if (sideIndicator && rnd <= fission_weight &&
+          demes.size() < d_params.max_demes) {
+        if (demes.size() == 1) {
+          demes.push_back(demes[chosenDeme].demeFission(gensElapsed, true));
+          rightDemes = 1;
+        } else {
+          demes.push_back(demes[chosenDeme].demeFission(gensElapsed));
+          if (rightIndicator) {
+            rightDemes++;
+          } else if (leftIndicator) {
+            leftDemes++;
+          }
+        }
+      } else {
+        demes[chosenDeme].pseudoFission();
+      }
     }
-    else {
-        std::cout << "Error: invalid event type" << std::endl;
-    }
+  }
 }
 
 /////// Sum all rates
 float Tumour::sumAllRates() {
-    float res = 0;
-    for (int i = 0; i < demes.size(); i++) {
-        res += demes[i].getSumOfRates();
-    }
-    return res;
+  float res = 0;
+  for (int i = 0; i < demes.size(); i++) {
+    res += demes[i].getSumOfRates();
+  }
+  return res;
 }
 
 /////// Getters
 // get total number of cells tracked in tumour
 int Tumour::getNumCells() const {
-    int res = 0;
-    for (int i = 0; i < demes.size(); i++) {
-        res += demes[i].getPopulation();
-    }
-    return res;
+  int res = 0;
+  for (int i = 0; i < demes.size(); i++) {
+    res += demes[i].getPopulation();
+  }
+  return res;
 }
 // get average number of fissions per deme
 float Tumour::getFissionsPerDeme() {
-    float res = 0;
-    for (int i = 0; i < demes.size(); i++) {
-        res += demes[i].getFissions();
-    }
-    res /= demes.size();
-    return res;
+  float res = 0;
+  for (int i = 0; i < demes.size(); i++) {
+    res += demes[i].getFissions();
+  }
+  res /= demes.size();
+  return res;
 }


### PR DESCRIPTION
Changes:
- Stopping conditions now related to the max number of fissions per deme (which is approx log2(total demes in tumour))
- Can choose how many demes per side to simulate
- Write to demes_final.csv every 5 generations (useful for methods chapter)

TO DO:
- [x] flag for writing to file
- [ ] clean up walter and methABC
- [x] flag for unrestricted spatial config (set either one of the side numbers to -1 and max_demes becomes 8 with no requirements on number of demes per side)
- [x] flag for extra turnover after tumour reaches final size - multiplier for gensElapsed